### PR TITLE
npm/jspm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build
 dist
 *.egg-info
+/node_modules

--- a/js/TrackballControls.js
+++ b/js/TrackballControls.js
@@ -3,6 +3,10 @@
  * @author Mark Lundin 	/ http://mark-lundin.com
  */
 
+if( typeof require === 'function' && !THREE ) {
+    var THREE = require( 'three' );
+}
+
 THREE.TrackballControls = function ( object, domElement ) {
 
 	var _this = this;

--- a/js/igraph.js
+++ b/js/igraph.js
@@ -1,5 +1,15 @@
-/*global THREE, $, jQuery, window, setTimeout*/
+/*global THREE, $, jQuery, window, setTimeout, require, module*/
 "use strict";
+
+// browserify support
+// More below after igraph is defined.
+if( typeof require === 'function' ) {
+    if( !$ ) var $ = require( 'jquery' );
+    if( !THREE ) {
+        var THREE = require( 'three' );
+        require( './TrackballControls' );
+    }
+}
 
 var igraph = {
 
@@ -349,3 +359,7 @@ var igraph = {
         }
     }
 };
+
+if( typeof module === 'object' ) {
+    module.exports = igraph;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "igraph",
+  "version": "0.1.0",
+  "description": "An embeddable webGL graph visualization library.",
+  "main": "js/igraph.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patrickfuller/igraph.git"
+  },
+  "author": "Patrick Fuller",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/patrickfuller/igraph/issues"
+  },
+  "homepage": "https://github.com/patrickfuller/igraph",
+  "dependencies": {
+    "jquery": "^2.1.4",
+    "three": "^0.71.0"
+  }
+}


### PR DESCRIPTION
Support for publishing and using the package through npm. Makes it easier to use it in browsers and also makes it compatible with jspm and the lovely ES6-style imports.

As far as I know it should still work the same in non-commonJS environments, but I didn't have a chance to test it in say IPython so you might want to do that before merging this.